### PR TITLE
Gsettings refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,8 @@ omit = [
     '*/.venv/*',
 ]
 
+[tool.coverage.report]
+show_missing = true
+
 [tool.pytest.ini_options]
 addopts = '--cov=wallsy'

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,11 +26,9 @@ platformdirs==2.2.0
 pluggy==0.13.1
 pre-commit==2.14.0
 py==1.10.0
-pycairo==1.20.1
 pycodestyle==2.7.0
 pyflakes==2.3.1
 Pygments==2.10.0
-PyGObject==3.40.1
 pyparsing==2.4.7
 pytest==6.2.4
 pytest-cov==2.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ install_requires =
     Click
     rich
     requests
-    PyGObject
     pillow
 packages = find:
 

--- a/wallsy/cli_utils/utils.py
+++ b/wallsy/cli_utils/utils.py
@@ -115,8 +115,8 @@ def _load_file(file: Path) -> Path:
 
     dest_path = config.WALLSY_MEDIA_DIR
 
-    # if file is not a Path, (can also be str or TextIOBuffer), convert to Path
-    file = Path(file).expanduser().resolve()
+    if not file.is_absolute():
+        file = file.expanduser().resolve()
     dest_path = dest_path / file.name
 
     # validate that the input file is a valid image.

--- a/wallsy/subcommands/desktop.py
+++ b/wallsy/subcommands/desktop.py
@@ -128,9 +128,6 @@ def _get_desktop(*args):
     """
 
     file = wallpaper_handler.get_current_wallpaper()
-    describe(
-        f":desktop_computer-emoji: 'desktop' retrieved current background '{file}'"
-    )
+    describe(f":desktop_computer-emoji: 'desktop' retrieved current background {file}")
     file = load(file)
-
     return file

--- a/wallsy/tests/test_image_handler.py
+++ b/wallsy/tests/test_image_handler.py
@@ -79,7 +79,6 @@ from itertools import cycle
 import pytest
 from requests import HTTPError
 from requests.exceptions import RequestException
-from gi.repository import Gio  # see PyObject API
 
 import wallsy.image_handler
 


### PR DESCRIPTION
This branch removes the PyGObject dependency from wallsy and replaces it with a subprocess call to the shell command 'gsettings'. This command is likely only present on Gnome systems. Since wallsy currently only supports Gnome desktop environments, this is an acceptable and desirable change as it removes a complicated dependency (PyGObject regularly fails on clean installation attempts due to missing dependencies) that degrades the install experience for end-users. 

Future improvements to wallsy that introduce support for other platforms need to replace calls to gsettings process with equivalents for those desktop environments (e.g. ctypes for windows or osascript for macOS). 